### PR TITLE
Loosen type hints on properties while maintaining behavior, to allow downstream static type analysis to accept more set values

### DIFF
--- a/phoebusgen/v4/properties/behavior.py
+++ b/phoebusgen/v4/properties/behavior.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import List, Optional, Union
 
 from .property_helpers import PropertyBase
 from .types import (
@@ -7,6 +8,7 @@ from .types import (
     ButtonMode,
     Color,
     ColorMode,
+    ColorType,
     InterpolationType,
     ObservableList,
     Rule,
@@ -17,9 +19,9 @@ from .types import (
 
 
 class HasActionsRulesAndScripts(PropertyBase):
-    actions: ObservableList[Action]
-    rules: ObservableList[Rule]
-    scripts: ObservableList[Script]
+    actions: List[Action]
+    rules: List[Rule]
+    scripts: List[Script]
 
 class HasToolTip(PropertyBase):
     tooltip: str
@@ -70,7 +72,7 @@ class HasEditable(PropertyBase):
     editable: bool
 
 class HasFallbackSymbol(PropertyBase):
-    fallback_symbol: Path
+    fallback_symbol: Optional[Union[Path, str]] = None
 
 class HasPreserveRatio(PropertyBase):
     preserve_ratio: bool = True
@@ -84,10 +86,10 @@ class HasArrayIndex(PropertyBase):
 
 class HasFallback(PropertyBase):
     fallback_label: str = 'Err'
-    fallback_color: Color = Color((255, 0, 255))
+    fallback_color: ColorType = Color((255, 0, 255))
 
 class HasStates(PropertyBase):
-    states: ObservableList[State] = ObservableList([State(label='State 1', color=Color((60, 100, 60))), State(value=1, label='State 2', color=Color((60, 255, 60)))])
+    states: List[State] = ObservableList([State(label='State 1', color=Color((60, 100, 60))), State(value=1, label='State 2', color=Color((60, 255, 60)))])
 
 class HasLogScale(PropertyBase):
     log_scale: bool
@@ -106,10 +108,10 @@ class HasColorMode(PropertyBase):
     color_mode: ColorMode = ColorMode.TYPE_MONO
 
 class HasItems(PropertyBase):
-    items: ObservableList[str]
+    items: List[str]
 
 class HasTraces(PropertyBase):
-    traces: ObservableList[Trace]
+    traces: List[Trace]
 
 class HasXAxis(PropertyBase):
     x_axis: Axis
@@ -118,7 +120,7 @@ class HasYAxis(PropertyBase):
     y_axis: Axis
 
 class HasYAxes(PropertyBase):
-    y_axes: ObservableList[Axis]
+    y_axes: List[Axis]
 
 class HasAutoScale(PropertyBase):
     auto_scale: bool = True

--- a/phoebusgen/v4/properties/display.py
+++ b/phoebusgen/v4/properties/display.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Optional
+from typing import Optional, List, Union
 
 from .property_helpers import PropertyBase
 from .types import (
@@ -7,6 +7,7 @@ from .types import (
     Color,
     ColorBar,
     ColorMap,
+    ColorType,
     Column,
     Font,
     Format,
@@ -46,8 +47,8 @@ class HasPointSize(PropertyBase):
     point_size: int
 
 class HasOnOffImages(PropertyBase):
-    off_image: Optional[Path] = None
-    on_image: Optional[Path] = None
+    off_image: Optional[Union[Path, str]] = None
+    on_image: Optional[Union[Path, str]] = None
 
 class HasOnOffLabels(PropertyBase):
     on_label: str = ''
@@ -80,17 +81,17 @@ class HasRotationStep(PropertyBase):
     rotation_step: RotationStep
 
 class HasLineColor(PropertyBase):
-    line_color: Color
+    line_color: ColorType
 
 class HasBackgroundColor(PropertyBase):
-    background_color: Color = Color((255, 255, 255))
+    background_color: ColorType = Color((255, 255, 255))
 
 class HasForegroundColor(PropertyBase):
-    foreground_color: Color = Color((0, 0, 0))
+    foreground_color: ColorType = Color((0, 0, 0))
 
 class HasOnOffColors(PropertyBase):
-    off_color: Color = Color((60, 100, 60))
-    on_color: Color = Color((60, 255, 60))
+    off_color: ColorType = Color((60, 100, 60))
+    on_color: ColorType = Color((60, 255, 60))
 
 class HasText(PropertyBase):
     text: str = ''
@@ -111,7 +112,7 @@ class HasLabelsFromPV(PropertyBase):
     labels_from_pv: bool = False
 
 class HasLabels(PropertyBase):
-    labels: ObservableList[str]
+    labels: List[str]
 
 class HasErrPV(PropertyBase):
     err_pv: str
@@ -174,7 +175,7 @@ class HasNumBits(PropertyBase):
     num_bits: int = 8
 
 class HasFillColor(PropertyBase):
-    fill_color: Color = Color((60, 255, 60))
+    fill_color: ColorType = Color((60, 255, 60))
 
 class HasShowValue(PropertyBase):
     show_value: bool = True
@@ -186,16 +187,16 @@ class HasShowIndex(PropertyBase):
     show_index: bool
 
 class HasDisconnectOverlayColor(PropertyBase):
-    disconnect_overlay_color: Color
+    disconnect_overlay_color: ColorType
 
 class HasColumns(PropertyBase):
-    columns: ObservableList[Column] = ObservableList([Column()])
+    columns: List[Column] = ObservableList([Column()])
 
 class HasScaleVisible(PropertyBase):
     scale_visible: bool
 
 class HasEmptyColor(PropertyBase):
-    empty_color: Color
+    empty_color: ColorType
 
 class HasGroupName(PropertyBase):
     group_name: str
@@ -244,7 +245,7 @@ class HasOpacity(PropertyBase):
     opacity: float = 1.0
 
 class HasPoints(PropertyBase):
-    points: ObservableList[Point]
+    points: List[Point]
 
 class HasLinearMeterColors(PropertyBase):
     colors: LinearMeterColors
@@ -268,6 +269,6 @@ class HasEnableGradient(PropertyBase):
     is_gradient_enabled: bool = False
 
 class HasStatusColors(PropertyBase):
-    normal_status_color: Color = Color((194, 198, 195))
-    minor_warning_color: Color = Color((242, 148, 141))
-    major_warning_color: Color = Color((240, 60, 46))
+    normal_status_color: ColorType = Color((194, 198, 195))
+    minor_warning_color: ColorType = Color((242, 148, 141))
+    major_warning_color: ColorType = Color((240, 60, 46))

--- a/phoebusgen/v4/properties/misc.py
+++ b/phoebusgen/v4/properties/misc.py
@@ -1,23 +1,25 @@
+from typing import List
+
 from .property_helpers import PropertyBase
-from .types import ROI, Color, Marker, ObservableList
+from .types import ROI, Color, ColorType, Marker
 
 
 class HasBorder(PropertyBase):
     border_width: int = 0
-    border_color: Color = Color((0, 0, 0))
+    border_color: ColorType = Color((0, 0, 0))
 
 class HasMarkers(PropertyBase):
-    markers: ObservableList[Marker]
+    markers: List[Marker]
 
 class HasGrid(PropertyBase):
     grid_visible: bool = True
-    grid_color: Color = Color((128, 128, 128))
+    grid_color: ColorType = Color((128, 128, 128))
     grid_step_x: int = 10
     grid_step_y: int = 10
 
 class HasKnobAndNeedleColor(PropertyBase):
-    needle_color: Color = Color((255, 5, 7))
-    knob_color: Color = Color((0, 0, 0))
+    needle_color: ColorType = Color((255, 5, 7))
+    knob_color: ColorType = Color((0, 0, 0))
 
 class HasSelectionPV(PropertyBase):
     selection_pv: str = ''
@@ -32,4 +34,4 @@ class HasCursor(PropertyBase):
     cursor_crosshair: bool = False
 
 class HasROIs(PropertyBase):
-    rois: ObservableList[ROI]
+    rois: List[ROI]

--- a/phoebusgen/v4/properties/property_helpers.py
+++ b/phoebusgen/v4/properties/property_helpers.py
@@ -5,7 +5,6 @@ from collections.abc import Mapping
 from dataclasses import dataclass, is_dataclass
 from enum import Enum
 from pathlib import Path
-from types import NoneType
 from typing import Callable, Dict, List, Optional, Sequence, Tuple, Type, TypeVar, Union
 from xml.etree.ElementTree import Element
 
@@ -47,6 +46,8 @@ PropertyType = Union[
     RuleExpression,
 ]
 PropertyTypeT = TypeVar('PropertyTypeT', bound=PropertyType)
+
+NoneType = type(None)  # Used for checking if a type is NoneType (e.g. for Optional[X] which is Union[X, NoneType])
 
 @dataclass
 class PropertyInfo:

--- a/phoebusgen/v4/properties/property_helpers.py
+++ b/phoebusgen/v4/properties/property_helpers.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, is_dataclass
 from enum import Enum
 from pathlib import Path
+from types import NoneType
 from typing import Callable, Dict, List, Optional, Sequence, Tuple, Type, TypeVar, Union
 from xml.etree.ElementTree import Element
 
@@ -49,12 +50,6 @@ PropertyTypeT = TypeVar('PropertyTypeT', bound=PropertyType)
 
 @dataclass
 class PropertyInfo:
-    """Class to hold information about a property, including its type and default value.
-
-    :param type: The type of the property
-    :param default_value: The default value of the property
-    """
-
     type: Type[PropertyTypeT]
     default_value: PropertyTypeT
 
@@ -87,7 +82,7 @@ def _unpack_union_type(union_type: Type[PropertyType]) -> Type[PropertyType]:
         raise ValueError(f"Type {union_type} is not a Union type!")
 
     args = get_args(union_type)
-    non_none_args = [arg for arg in args if arg is not type(None)]
+    non_none_args = [arg for arg in args if arg is not NoneType]
     if len(non_none_args) == 0:
         raise ValueError(f"Union type {union_type} has no non-None types!")
     return non_none_args[0]
@@ -105,10 +100,14 @@ def _normalize_property_type(property_type: Type[PropertyType]) -> Type[Property
     args = get_args(property_type)
     if args:
         origin = get_origin(property_type)
+        # On Python < 3.9, builtin types (list, dict, tuple) don't support
+        # subscripting directly; use their typing module equivalents instead.
+        _builtin_to_typing = {list: List, dict: Dict, tuple: Tuple}
+        subscriptable = _builtin_to_typing.get(origin, origin)
         normalized_args = tuple(_normalize_property_type(arg) for arg in args)
         if len(normalized_args) == 1:
-            return origin[normalized_args[0]]
-        return origin[normalized_args]
+            return subscriptable[normalized_args[0]]
+        return subscriptable[normalized_args]
     return property_type
 
 

--- a/phoebusgen/v4/properties/property_helpers.py
+++ b/phoebusgen/v4/properties/property_helpers.py
@@ -50,7 +50,7 @@ PropertyTypeT = TypeVar('PropertyTypeT', bound=PropertyType)
 @dataclass
 class PropertyInfo:
     """Class to hold information about a property, including its type and default value.
-    
+
     :param type: The type of the property
     :param default_value: The default value of the property
     """
@@ -95,7 +95,7 @@ def _unpack_union_type(union_type: Type[PropertyType]) -> Type[PropertyType]:
 
 def _normalize_property_type(property_type: Type[PropertyType]) -> Type[PropertyType]:
     """Given a property type, normalize it to a single type for use in the _all_properties dictionary.
-    
+
     :param property_type: The property type to normalize
     :return: The normalized property type
     """
@@ -113,7 +113,7 @@ def _normalize_property_type(property_type: Type[PropertyType]) -> Type[Property
 
 
 def _make_default_prop_val(property_type: Type[PropertyType]) -> PropertyType:
-    """Given a property type, return a default value for it. 
+    """Given a property type, return a default value for it.
 
     For example, for int return 0, for str return '', for ObservableList return an empty list, etc.
 

--- a/phoebusgen/v4/properties/property_helpers.py
+++ b/phoebusgen/v4/properties/property_helpers.py
@@ -15,7 +15,14 @@ try:
     from typing import get_args, get_origin  # novermin
 except ImportError:
     def get_origin(tp):
-        return getattr(tp, '__origin__', None)
+        origin = getattr(tp, '__origin__', None)
+        if origin == List:
+            return list
+        elif origin == Dict:
+            return dict
+        elif origin == Tuple:
+            return tuple
+        return origin
 
     def get_args(tp):
         return getattr(tp, '__args__', ())

--- a/phoebusgen/v4/properties/property_helpers.py
+++ b/phoebusgen/v4/properties/property_helpers.py
@@ -49,17 +49,90 @@ PropertyTypeT = TypeVar('PropertyTypeT', bound=PropertyType)
 
 @dataclass
 class PropertyInfo:
+    """Class to hold information about a property, including its type and default value.
+    
+    :param type: The type of the property
+    :param default_value: The default value of the property
+    """
+
     type: Type[PropertyTypeT]
     default_value: PropertyTypeT
 
+
 def _create_element(prop_name: str, value: Optional[str] = None) -> Element:
+    """Create an XML element with the given property name and optional value.
+
+    :param prop_name: The name of the property
+    :param value: The optional value of the property
+    :return: An XML element with the given property name and value
+    """
+
     element = Element(prop_name)
     if value is not None:
         element.text = str(value)
     return element
 
+
+def _unpack_union_type(union_type: Type[PropertyType]) -> Type[PropertyType]:
+    """Given a Union type, return the first non-None type in the union.
+
+    For example, given Union[int, None], this function will return int.
+    If there are multiple non-None types, the first one is returned.
+    If there are no non-None types, None is returned.
+
+    :param union_type: The Union type to unpack
+    :return: The first non-None type in the union, or None if there are no non-None types
+    """
+    if get_origin(union_type) is not Union:
+        raise ValueError(f"Type {union_type} is not a Union type!")
+
+    args = get_args(union_type)
+    non_none_args = [arg for arg in args if arg is not type(None)]
+    if len(non_none_args) == 0:
+        raise ValueError(f"Union type {union_type} has no non-None types!")
+    return non_none_args[0]
+
+
+def _normalize_property_type(property_type: Type[PropertyType]) -> Type[PropertyType]:
+    """Given a property type, normalize it to a single type for use in the _all_properties dictionary.
+    
+    :param property_type: The property type to normalize
+    :return: The normalized property type
+    """
+
+    if get_origin(property_type) is Union:
+        return _normalize_property_type(_unpack_union_type(property_type))
+    args = get_args(property_type)
+    if args:
+        origin = get_origin(property_type)
+        normalized_args = tuple(_normalize_property_type(arg) for arg in args)
+        if len(normalized_args) == 1:
+            return origin[normalized_args[0]]
+        return origin[normalized_args]
+    return property_type
+
+
+def _make_default_prop_val(property_type: Type[PropertyType]) -> PropertyType:
+    """Given a property type, return a default value for it. 
+
+    For example, for int return 0, for str return '', for ObservableList return an empty list, etc.
+
+    :param property_type: The type of the property to create a default value for
+    :return: A default value for the property type
+    """
+
+    if get_origin(property_type) is list:
+        return ObservableList()
+    elif get_origin(property_type) is dict:
+        return ObservableDict()
+    elif isinstance(property_type, type) and issubclass(property_type, Enum):
+        return list(property_type)[0]
+    else:
+        return property_type()  # Call the type to get a default value (e.g. int() -> 0, str() -> '', etc.)
+
+
 class PropertyMetaclass(type):
-    def __new__(mcs, name, bases, attrs):
+    def __new__(mcs, name: str, bases: List[Type], attrs: Dict[str, object]) -> Type:
 
         # Keep a running dictionary of all properties defined by all property mixin classes,
         # so that we can look up property types and default values by name at runtime for any
@@ -72,13 +145,12 @@ class PropertyMetaclass(type):
         def getter(self: 'PropertyBase', prop_name: str, property_type: Type[PropertyType]) -> PropertyType:
             tag_name = self._get_property_tag_name(prop_name)
             element = self.root.find(tag_name) if tag_name is not None else self.root
-
             if element is not None:
                 # Get the appropriate getter function for the property type
                 typed_getter = self._find_getter_by_type(property_type)
 
                 # For lists, we pass the item type instead
-                if get_origin(property_type) is ObservableList:
+                if get_origin(property_type) is list:
                     property_type = get_args(property_type)[0]
 
                 # Based on the function signature, dynamically create a list of arguments
@@ -113,7 +185,7 @@ class PropertyMetaclass(type):
             # Remove existing property element if found
             if tag_name is not None and self.root.find(tag_name) is not None:
                 self.root.remove(self.root.find(tag_name))
-            elif tag_name is None and get_origin(property_type) is ObservableList:
+            elif tag_name is None and get_origin(property_type) is list:
                 # For list properties stored as direct children (tag_name=None),
                 # remove all existing child elements with the item tag name
                 item_tag = self._get_list_item_tag_name(prop_name)
@@ -133,28 +205,18 @@ class PropertyMetaclass(type):
         if name not in ['PropertyBase', 'Widget', 'Screen'] and not any(base.__name__ in ['Widget', 'Screen'] for base in bases):
             all_properties[cls] = {}
             for prop_name, annotation in cls.__annotations__.items():
-                base_prop_type = annotation
 
                 # Unwrap Optional[X] (Union[X, None]) to X for property type resolution
-                unwrapped = annotation
-                if get_origin(annotation) is Union:
-                    args = get_args(annotation)
-                    non_none_args = [a for a in args if a is not type(None)]
-                    unwrapped = non_none_args[0]
+                property_type = _normalize_property_type(annotation)
+                default_value = attrs.get(prop_name, _make_default_prop_val(property_type))
 
-                if hasattr(unwrapped, '__origin__'):
-                    property_type = unwrapped.__origin__
-                else:
-                    property_type = unwrapped
-                default_value = attrs.get(prop_name, property_type() if not issubclass(property_type, Enum) else list(property_type)[0])
-
-                def prop_getter(self, prop_name=prop_name, prop_type=annotation):
+                def prop_getter(self, prop_name=prop_name, prop_type=property_type):
                     return getter(self, prop_name, prop_type)
-                def prop_setter(self, value, prop_name=prop_name, prop_type=annotation):
+                def prop_setter(self, value, prop_name=prop_name, prop_type=property_type):
                     return setter(self, prop_name, prop_type, value)
 
                 setattr(cls, prop_name, property(prop_getter, prop_setter))
-                all_properties[cls][prop_name] = PropertyInfo(type=base_prop_type, default_value=default_value)
+                all_properties[cls][prop_name] = PropertyInfo(type=property_type, default_value=default_value)
 
 
         # Collect property names and types from base classes to keep a running dictionary
@@ -230,7 +292,7 @@ class PropertyBase(metaclass=PropertyMetaclass):
         """
 
         property_type = cls.get_property_type_by_name(property_name)
-        if tag_name is None and get_origin(property_type) not in (ObservableList, ObservableDict):
+        if tag_name is None and get_origin(property_type) not in (list, dict):
             raise ValueError(f"Only list or dict properties can have tag_name set to None, but property '{property_name}' is of type '{property_type}'!")
 
         # Ensure we have a per-class dict rather than mutating a parent class's dict
@@ -338,18 +400,20 @@ class PropertyBase(metaclass=PropertyMetaclass):
         if base_prop_type is None:
             raise ValueError(f"Property type for prop_id '{prop_id}' not found in all_properties dictionary!")
 
+        base_prop_type = _normalize_property_type(base_prop_type)
+
         def get_nested_property_type(prop_id: str, base_type: type):
-            if get_origin(base_type) is ObservableList:
+            if get_origin(base_type) is list:
                 return get_nested_property_type(prop_id.split(']', 1)[1], get_args(base_type)[0])
-            elif get_origin(base_type) is ObservableDict:
+            elif get_origin(base_type) is dict:
                 return get_nested_property_type(prop_id.split('.', 1)[1], get_args(base_type)[1])
-            elif issubclass(base_type, ObservableDataclass):
+            elif is_dataclass(base_type):
                 dataclass_field_name = prop_id.split('.')[1]
                 if '[' in dataclass_field_name:
                     dataclass_field_name = dataclass_field_name.split('[')[0]
                 dataclass_fields = base_type.fields()
                 if dataclass_field_name in dataclass_fields:
-                    field_type = dataclass_fields[dataclass_field_name].type
+                    field_type = _normalize_property_type(dataclass_fields[dataclass_field_name].type)
                     return get_nested_property_type(prop_id.split('.', 1)[1], field_type)
             else:
                 return base_type
@@ -391,41 +455,26 @@ class PropertyBase(metaclass=PropertyMetaclass):
         :param prefix: 'get' to find a getter, 'set' to find a setter
         :return: The getter or setter function for the property type
         """
-        # Unwrap Optional[X] (Union[X, None]) to X
-        if get_origin(property_type) is Union:
-            args = get_args(property_type)
-            non_none_args = [a for a in args if a is not type(None)]
-            if len(non_none_args) == 1:
-                property_type = non_none_args[0]
 
+        base_property_type = property_type
         if hasattr(property_type, '__origin__'):
-            property_type = property_type.__origin__
+            base_property_type = property_type.__origin__
 
-        property_type_str = property_type.__name__.lower()
+        property_type_str = ''.join(['_' + c.lower() if c.isupper() and i != 0 else c.lower() for i, c in enumerate(base_property_type.__name__)]).lstrip('_')
 
         method_name = f'_{prefix}_{property_type_str}_property'
         if hasattr(cls, method_name):
             return getattr(cls, method_name)
-        elif issubclass(property_type, PhoebusElement):
-            return getattr(cls, f'_{prefix}_element_property')
-        elif property_type is tuple:
-            return getattr(cls, f'_{prefix}_color_property')
         elif issubclass(property_type, Action):
             return getattr(cls, f'_{prefix}_action_property')
-        elif property_type is Rule:
-            return getattr(cls, f'_{prefix}_rule_property')
         elif property_type is RuleExpression:
             return getattr(cls, f'_{prefix}_rule_expression_property')
-        elif property_type is ObservableList:
-            return getattr(cls, f'_{prefix}_list_property')
-        elif property_type is ObservableDict:
-            return getattr(cls, f'_{prefix}_dict_property')
-        elif issubclass(property_type, Enum):
+        elif issubclass(property_type, PhoebusElement):
+            return getattr(cls, f'_{prefix}_element_property')
+        elif isinstance(property_type, type) and issubclass(property_type, Enum):
             return getattr(cls, f'_{prefix}_enum_property')
         elif is_dataclass(property_type):
             return getattr(cls, f'_{prefix}_dataclass_property')
-        elif property_type is Path:
-            return getattr(cls, f'_{prefix}_path_property')
         elif property_type in (int, float, str, bool):
             return getattr(cls, f'_{prefix}_primitive_property')
 
@@ -625,23 +674,15 @@ class PropertyBase(metaclass=PropertyMetaclass):
         field_values = {}
         for field in property_type.fields():
             field_elem = element.find(field)
-            field_type = property_type.fields()[field].type
-
-            # Unwrap Optional[X] to get the inner type for parsing
-            inner_type = field_type
-            if get_origin(field_type) is Union:
-                args = get_args(field_type)
-                non_none_args = [a for a in args if a is not type(None)]
-                if len(non_none_args) == 1:
-                    inner_type = non_none_args[0]
+            field_type = _normalize_property_type(property_type.fields()[field].type)
 
             if field_elem is None and field in element.attrib:
-                field_values[field] = inner_type(element.attrib[field])
-            elif field_elem is not None and (field_elem.text is not None or inner_type not in (int, float, str, bool, Path)):
-                typed_getter = cls._find_getter_by_type(inner_type)
+                field_values[field] = field_type(element.attrib[field])
+            elif field_elem is not None and (field_elem.text is not None or field_type not in (int, float, str, bool, Path)):
+                typed_getter = cls._find_getter_by_type(field_type)
                 getter_args = [field_elem]
                 if len(inspect.signature(typed_getter).parameters) > 1:
-                    getter_args.append(inner_type)
+                    getter_args.append(field_type)
                 field_values[field] = typed_getter(*getter_args)
 
         return property_type(**field_values)
@@ -662,17 +703,10 @@ class PropertyBase(metaclass=PropertyMetaclass):
 
         for field in value.fields():
             field_value = getattr(value, field)
-            field_type = property_cls.fields()[field].type
+            field_type = _normalize_property_type(property_cls.fields()[field].type)
+            valid = cls._is_set_value_valid(field_value, field_type)
 
-            # Determine if this is an Optional[Path] field that should be written even when None
-            is_optional_path = False
-            if get_origin(field_type) is Union:
-                args = get_args(field_type)
-                non_none_args = [a for a in args if a is not type(None)]
-                if len(non_none_args) == 1 and non_none_args[0] is Path:
-                    is_optional_path = True
-
-            if field_value is not None or is_optional_path:
+            if valid:
                 if field in value._attrib_fields:
                     if field_type in (int, float, str, bool):
                         element.attrib[field] = str(field_value)
@@ -684,6 +718,8 @@ class PropertyBase(metaclass=PropertyMetaclass):
                     typed_setter = cls._find_setter_by_type(field_type)
                     sub_elem = typed_setter(field, field_value)
                     element.append(sub_elem)
+            else:
+                raise TypeError(f"Value {field_value} is of invalid type for field '{field}' of dataclass '{property_cls.__name__}': must be of type {field_type}")
         return element
 
 
@@ -962,35 +998,28 @@ class PropertyBase(metaclass=PropertyMetaclass):
         :return: True if the value is valid for the expected type, False otherwise
         """
 
-        # Unwrap Optional[X] and allow None
-        is_optional = False
-        if get_origin(expected_type) is Union:
-            args = get_args(expected_type)
-            non_none_args = [a for a in args if a is not type(None)]
-            if len(non_none_args) < len(args):
-                is_optional = True
-            expected_type = non_none_args[0]
-
-        if is_optional and value is None:
-            return True
-
         def _validate_element(value: PropertyType, expected_type: Type[PropertyType]) -> bool:
             if expected_type is Color:
                 return Color.is_color(value)
-            elif expected_type is ObservableDict:
-                return isinstance(value, Mapping)
             elif expected_type is float:
                 return isinstance(value, (float, int))
             elif expected_type is Path:
-                return isinstance(value, (Path, str))
+                return isinstance(value, (Path, str, type(None)))
             else:
                 return isinstance(value, expected_type)
 
-        if get_origin(expected_type) is ObservableList:
+        if get_origin(expected_type) is list:
             expected_type = get_args(expected_type)[0]
             if not isinstance(value, Sequence):
                 return False
             else:
                 return all(_validate_element(v, expected_type) for v in value)
+
+        if get_origin(expected_type) is dict:
+            key_type, val_type = get_args(expected_type)
+            if not isinstance(value, Mapping):
+                return False
+            else:
+                return all(isinstance(k, key_type) and _validate_element(v, val_type) for k, v in value.items())
 
         return _validate_element(value, expected_type)

--- a/phoebusgen/v4/properties/property_helpers.py
+++ b/phoebusgen/v4/properties/property_helpers.py
@@ -79,6 +79,7 @@ def _unpack_union_type(union_type: Type[PropertyType]) -> Type[PropertyType]:
     :param union_type: The Union type to unpack
     :return: The first non-None type in the union, or None if there are no non-None types
     """
+
     if get_origin(union_type) is not Union:
         raise ValueError(f"Type {union_type} is not a Union type!")
 

--- a/phoebusgen/v4/properties/types.py
+++ b/phoebusgen/v4/properties/types.py
@@ -2,7 +2,7 @@ from collections.abc import MutableMapping, MutableSequence
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, Dict, Generic, List, Optional, TypeVar, Union
+from typing import Any, Callable, Dict, Generic, List, Optional, Tuple, TypeVar, Union
 
 Primitive = Union[int, float, str, bool]
 
@@ -75,7 +75,7 @@ class Color(tuple):
         return tuple(self) == tuple(other)
 
 
-ColorType = Union[Color, tuple[int, int, int, int], tuple[int, int, int], str]
+ColorType = Union[Color, Tuple[int, int, int, int], Tuple[int, int, int], str]
 
 class FontStyle(str, Enum):
     REGULAR = 'REGULAR'

--- a/phoebusgen/v4/properties/types.py
+++ b/phoebusgen/v4/properties/types.py
@@ -2,7 +2,7 @@ from collections.abc import MutableMapping, MutableSequence
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, Generic, List, Optional, TypeVar, Union
+from typing import Any, Callable, Dict, Generic, List, Optional, TypeVar, Union
 
 Primitive = Union[int, float, str, bool]
 
@@ -74,6 +74,8 @@ class Color(tuple):
                 return False
         return tuple(self) == tuple(other)
 
+
+ColorType = Union[Color, tuple[int, int, int, int], tuple[int, int, int], str]
 
 class FontStyle(str, Enum):
     REGULAR = 'REGULAR'
@@ -366,19 +368,19 @@ class Column(ObservableDataclass):
     name: str = ''
     width: int = 100
     editable: bool = True
-    options: ObservableList[str] = field(default_factory=ObservableList[str])
+    options: List[str] = field(default_factory=ObservableList[str])
 
 @dataclass
 class State(ObservableDataclass):
     value: int = 0
     label: str = ''
-    color: Color = field(default_factory=Color)
+    color: ColorType = field(default_factory=Color)
 
 
 @dataclass
 class ROI(ObservableDataclass):
     name: str = ''
-    color: Color = field(default_factory=lambda: Color((0, 255, 0)))
+    color: ColorType = field(default_factory=lambda: Color((0, 255, 0)))
     visible: bool = True
     interactive: bool = True
     x_pv: str = ''
@@ -405,7 +407,7 @@ class Axis(ObservableDataclass):
     show_grid: bool = True
     title_font: Font = field(default_factory=Font)
     scale_font: Font = field(default_factory=Font)
-    color: Color = field(default_factory=Color)
+    color: ColorType = field(default_factory=Color)
 
 @dataclass
 class Trace(ObservableDataclass):
@@ -415,7 +417,7 @@ class Trace(ObservableDataclass):
     error_pv: str = ''
     y_axis: int = 0
     trace_type: TraceType = TraceType.LINE
-    color: Color = field(default_factory=lambda: Color((0, 0, 255)))
+    color: ColorType = field(default_factory=lambda: Color((0, 0, 255)))
     line_width: int = 1
     line_style: LineStyle = LineStyle.SOLID
     point_type: PointType = PointType.NONE
@@ -426,13 +428,13 @@ class Trace(ObservableDataclass):
 class NavTab(ObservableDataclass):
     name: str = ''
     file: Optional[Path] = None
-    macros: ObservableDict = field(default_factory=ObservableDict)
+    macros: Dict[str, str] = field(default_factory=ObservableDict)
     group_name: str = ''
 
 @dataclass
 class Script(ObservableDataclass):
     file: Optional[Path] = None
-    pv_names: ObservableList[str] = field(default_factory=ObservableList[str])
+    pv_names: List[str] = field(default_factory=ObservableList[str])
 
 @dataclass
 class EmbeddedScript(Script):
@@ -447,7 +449,7 @@ class Action(ObservableDataclass):
 class OpenDisplayAction(Action):
     file: Optional[Path] = None
     target: OpenDisplayTarget = OpenDisplayTarget.REPLACE
-    macros: ObservableDict = field(default_factory=ObservableDict)
+    macros: Dict[str, str] = field(default_factory=ObservableDict)
 
 @dataclass
 class WritePvAction(Action):
@@ -485,13 +487,13 @@ class RulePvName(ObservableDataclass):
 class Rule(ObservableDataclass):
     name: str = 'New Rule'
     prop_id: str = 'name'
-    expressions: ObservableList[RuleExpression] = field(default_factory=ObservableList[RuleExpression])
-    pv_names: ObservableDict = field(default_factory=ObservableDict)
+    expressions: List[RuleExpression] = field(default_factory=ObservableList[RuleExpression])
+    pv_names: Dict[str, RulePvName] = field(default_factory=ObservableDict)
     out_exp: bool = False
 
 @dataclass
 class Instance(ObservableDataclass):
-    macros: ObservableDict = field(default_factory=ObservableDict)
+    macros: Dict[str, str] = field(default_factory=ObservableDict)
 
 
 @dataclass
@@ -507,12 +509,12 @@ class LinearMeterColors(ObservableDataclass):
     """
 
     # Default colors taken from Phoebus LinearMeter widget
-    foreground_color: Color = field(default_factory=lambda: Color((0, 0, 0)))
-    background_color: Color = field(default_factory=lambda: Color((0, 0, 0, 0)))
-    needle_color: Color = field(default_factory=lambda: Color((0, 0, 0)))
-    knob_color: Color = field(default_factory=lambda: Color((0, 0, 0)))
-    normal_status_color: Color = field(default_factory=lambda: Color((194, 198, 195)))
-    minor_warning_color: Color = field(default_factory=lambda: Color((242, 148, 141)))
-    major_warning_color: Color = field(default_factory=lambda: Color((240, 60, 46)))
+    foreground_color: ColorType = field(default_factory=lambda: Color((0, 0, 0)))
+    background_color: ColorType = field(default_factory=lambda: Color((0, 0, 0, 0)))
+    needle_color: ColorType = field(default_factory=lambda: Color((0, 0, 0)))
+    knob_color: ColorType = field(default_factory=lambda: Color((0, 0, 0)))
+    normal_status_color: ColorType = field(default_factory=lambda: Color((194, 198, 195)))
+    minor_warning_color: ColorType = field(default_factory=lambda: Color((242, 148, 141)))
+    major_warning_color: ColorType = field(default_factory=lambda: Color((240, 60, 46)))
     is_gradient_enabled: bool = False
     is_highlighting_of_active_regions_enabled: bool = True

--- a/phoebusgen/v4/properties/widget.py
+++ b/phoebusgen/v4/properties/widget.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Optional
+from typing import Dict, List, Optional, Union
 
 from phoebusgen.v4.properties.behavior import HasToolTip
 from phoebusgen.v4.properties.display import HasTabActiveHeightDirection
@@ -9,8 +9,6 @@ from .types import (
     FileComponent,
     Instance,
     NavTab,
-    ObservableDict,
-    ObservableList,
     TabDirection,
 )
 
@@ -19,13 +17,13 @@ class HasPVName(HasToolTip):
     tool_tip: str = '$(pv_name)\n$(pv_value)'
 
 class HasMacros(PropertyBase):
-    macros: ObservableDict
+    macros: Dict[str, str]
 
 class HasName(PropertyBase):
     name: str = ''
 
 class HasFile(PropertyBase):
-    file: Optional[Path] = None
+    file: Optional[Union[Path, str]] = None
 
 class HasUrl(PropertyBase):
     url: str = ''
@@ -40,14 +38,14 @@ class HasLabel(PropertyBase):
     label: str = ''
 
 class HasNavTabs(HasTabActiveHeightDirection):
-    tabs: ObservableList[NavTab]
+    tabs: List[NavTab]
     tab_spacing: int = 2
     tab_width: int = 100
     direction: TabDirection = TabDirection.VERTICAL # Navtabs use vertical tabs by default
     active_tab: int = 0 # NavTabs use 0-based indexing for active tab, while Tabs use 1-based indexing
 
 class HasInstances(PropertyBase):
-    instances: ObservableList[Instance]
+    instances: List[Instance]
 
 class HasSymbols(PropertyBase):
-    symbols: ObservableList[str]
+    symbols: List[str]

--- a/phoebusgen/v4/widgets/structure.py
+++ b/phoebusgen/v4/widgets/structure.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Optional, Union
+from typing import List, Optional, Union
 from xml.etree.ElementTree import Element, SubElement
 
 from phoebusgen.v4.properties.behavior import HasAlarmBorder
@@ -21,7 +21,6 @@ from phoebusgen.v4.properties.display import (
 )
 from phoebusgen.v4.properties.misc import HasBorder
 from phoebusgen.v4.properties.property_helpers import PropertyBase
-from phoebusgen.v4.properties.types import Color, ObservableList
 from phoebusgen.v4.properties.widget import (
     HasFile,
     HasInstances,
@@ -154,7 +153,7 @@ class Tab(HasWidgets, HasName):
 class HasTabs(PropertyBase):
     """Interface for widgets that contain tabs that contain other widgets"""
 
-    tabs: ObservableList[Tab]
+    tabs: List[Tab]
 
 
 class Tabs(Widget, HasTabs, HasMacros, HasTabActiveHeightDirection, HasFont, HasBackgroundColor):

--- a/phoebusgen/v4/widgets/widget.py
+++ b/phoebusgen/v4/widgets/widget.py
@@ -220,7 +220,7 @@ class Widget(PhoebusElement, HasParent, HasVisible, HasName, HasPosition, HasAct
 
 class HasWidgets(PhoebusElement, PropertyBase):
 
-    widgets: ObservableList[Widget]
+    widgets: List[Widget]
 
     def __init__(self, widgets_tag_name: Optional[str] = None) -> None:
         """Interface for widgets that contain other widgets.

--- a/tests/v4/test_properties/test_properties_base.py
+++ b/tests/v4/test_properties/test_properties_base.py
@@ -675,7 +675,7 @@ def test_unpack_union_type_raises_on_non_union(non_union_type):
     (Union[ObservableList[Axis], None], ObservableList[Axis]),
     (ObservableList[Axis], ObservableList[Axis]),
     (Optional[ObservableList[Axis]], ObservableList[Axis]),
-    (Union[Dict[str, bool], None], ObservableDict[str, bool]),
+    (Union[Dict[str, bool], None], Dict[str, bool]),
     (Optional[Union[Path, str]], Path),
 ])
 def test_normalize_property_type(property_type, expected):

--- a/tests/v4/test_properties/test_properties_base.py
+++ b/tests/v4/test_properties/test_properties_base.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from pathlib import Path
+from typing import Dict, List, Optional, Union
 from xml.etree.ElementTree import Element, SubElement, fromstring
 
 import pytest
@@ -22,12 +23,19 @@ from phoebusgen.v4.properties.display import (
 )
 from phoebusgen.v4.properties.misc import HasMarkers
 from phoebusgen.v4.properties.position import HasPosition
-from phoebusgen.v4.properties.property_helpers import PropertyBase, _create_element
+from phoebusgen.v4.properties.property_helpers import (
+    PropertyBase,
+    _create_element,
+    _make_default_prop_val,
+    _normalize_property_type,
+    _unpack_union_type,
+)
 from phoebusgen.v4.properties.types import (
     Action,
     ArrowTypes,
     Axis,
     Color,
+    ColorType,
     FileComponent,
     Font,
     FontStyle,
@@ -71,8 +79,8 @@ def test_create_element():
     (str, PropertyBase._get_primitive_property, PropertyBase._set_primitive_property),
     (float, PropertyBase._get_primitive_property, PropertyBase._set_primitive_property),
     (bool, PropertyBase._get_primitive_property, PropertyBase._set_primitive_property),
-    (ObservableDict, PropertyBase._get_dict_property, PropertyBase._set_dict_property),
-    (ObservableList[int], PropertyBase._get_list_property, PropertyBase._set_list_property),
+    (Dict[str, str], PropertyBase._get_dict_property, PropertyBase._set_dict_property),
+    (List[int], PropertyBase._get_list_property, PropertyBase._set_list_property),
     (FileComponent, PropertyBase._get_enum_property, PropertyBase._set_enum_property),
     (Color, PropertyBase._get_color_property, PropertyBase._set_color_property),
     (Font, PropertyBase._get_font_property, PropertyBase._set_font_property),
@@ -99,16 +107,18 @@ def test_find_getter_setter_by_type(prop_type, expected_getter, expected_setter)
     ((255, 255, 255), Color, True),
     ('#FFAABB', Color, True),
     (Font(), Font, True),
-    (ObservableDict(), ObservableDict, True),
-    ({}, ObservableDict, True),
-    (ObservableList[int](), ObservableList[int], True),
-    ([], ObservableList[str], True),
-    ([1, 'str'], ObservableList[int], False),
+    (ObservableDict(), Dict[str, str], True),
+    ({}, Dict[str, str], True),
+    ({'key': 'value'}, Dict[str, str], True),
+    ({'key': 123}, Dict[str, str], False),
+    (ObservableList(), List[int], True),
+    ([], List[str], True),
+    ([1, 'str'], List[int], False),
     (FileComponent.DIRECTORY, FileComponent, True),
     ('not-a-color', Color, False),
     (123, str, False),
-    ([], ObservableDict, False),
-    (['item1', 'item2', 'item3'], ObservableList[str], True),
+    ([], Dict[str, str], False),
+    (['item1', 'item2', 'item3'], List[str], True),
 ])
 def test_is_set_value_valid(value, expected_type, expected_valid):
     is_valid = PropertyBase._is_set_value_valid(value, expected_type)
@@ -586,7 +596,7 @@ def test_get_property_type_by_name():
     xy_plot = XYPlot(name='Test Plot', x=10, y=20, width=400, height=300)
     assert xy_plot.get_property_type_by_name('x') is int
     assert xy_plot.get_property_type_by_name('background_color') is Color
-    assert xy_plot.get_property_type_by_name('y_axes') == ObservableList[Axis]
+    assert xy_plot.get_property_type_by_name('y_axes') == list[Axis]
     assert xy_plot.get_property_type_by_name('x_axis') is Axis
 
     with pytest.raises(ValueError, match="Widget 'XYPlot' has no property 'nonexistent'!"):
@@ -622,3 +632,70 @@ def test_primitive_property_with_no_value_in_xml():
 """
     label = Label.from_element(fromstring(xml_string))
     assert label.text == ''
+
+
+# --- Tests for _unpack_union_type ---
+
+@pytest.mark.parametrize('union_type, expected', [
+    (Optional[int], int),
+    (Optional[str], str),
+    (Optional[Color], Color),
+    (Union[int, None], int),
+    (Union[str, None], str),
+    (Union[float, int, None], float),
+    (Union[ObservableList[Axis], None], ObservableList[Axis]),
+])
+def test_unpack_union_type(union_type, expected):
+    assert _unpack_union_type(union_type) == expected
+
+
+@pytest.mark.parametrize('non_union_type', [
+    int,
+    str,
+    Color,
+    ObservableList[Axis],
+])
+def test_unpack_union_type_raises_on_non_union(non_union_type):
+    with pytest.raises(ValueError, match="is not a Union type"):
+        _unpack_union_type(non_union_type)
+
+
+# --- Tests for _normalize_property_type ---
+
+@pytest.mark.parametrize('property_type, expected', [
+    (int, int),
+    (str, str),
+    (float, float),
+    (bool, bool),
+    (Color, Color),
+    (ColorType, Color),
+    (Optional[int], int),
+    (Optional[str], str),
+    (Optional[Color], Color),
+    (Union[ObservableList[Axis], None], ObservableList[Axis]),
+    (ObservableList[Axis], ObservableList[Axis]),
+    (Optional[ObservableList[Axis]], ObservableList[Axis]),
+    (Union[ObservableDict[str, bool], None], ObservableDict[str, bool]),
+    (Optional[Union[Path, str]], Path),
+])
+def test_normalize_property_type(property_type, expected):
+    assert _normalize_property_type(property_type) == expected
+
+
+# --- Tests for _make_default_prop_val ---
+
+@pytest.mark.parametrize('property_type, expected_type, expected_value', [
+    (int, int, 0),
+    (float, float, 0.0),
+    (str, str, ''),
+    (bool, bool, False),
+    (ObservableList[Axis], ObservableList, None),
+    (ObservableDict[str, bool], ObservableDict, None),
+    (TraceType, TraceType, list(TraceType)[0]),
+    (FontStyle, FontStyle, list(FontStyle)[0]),
+])
+def test_make_default_prop_val(property_type, expected_type, expected_value):
+    result = _make_default_prop_val(property_type)
+    assert isinstance(result, expected_type)
+    if expected_value is not None:
+        assert result == expected_value

--- a/tests/v4/test_properties/test_properties_base.py
+++ b/tests/v4/test_properties/test_properties_base.py
@@ -596,7 +596,7 @@ def test_get_property_type_by_name():
     xy_plot = XYPlot(name='Test Plot', x=10, y=20, width=400, height=300)
     assert xy_plot.get_property_type_by_name('x') is int
     assert xy_plot.get_property_type_by_name('background_color') is Color
-    assert xy_plot.get_property_type_by_name('y_axes') == list[Axis]
+    assert xy_plot.get_property_type_by_name('y_axes') == List[Axis]
     assert xy_plot.get_property_type_by_name('x_axis') is Axis
 
     with pytest.raises(ValueError, match="Widget 'XYPlot' has no property 'nonexistent'!"):

--- a/tests/v4/test_properties/test_properties_base.py
+++ b/tests/v4/test_properties/test_properties_base.py
@@ -675,7 +675,7 @@ def test_unpack_union_type_raises_on_non_union(non_union_type):
     (Union[ObservableList[Axis], None], ObservableList[Axis]),
     (ObservableList[Axis], ObservableList[Axis]),
     (Optional[ObservableList[Axis]], ObservableList[Axis]),
-    (Union[ObservableDict[str, bool], None], ObservableDict[str, bool]),
+    (Union[Dict[str, bool], None], ObservableDict[str, bool]),
     (Optional[Union[Path, str]], Path),
 ])
 def test_normalize_property_type(property_type, expected):

--- a/tests/v4/test_properties/test_properties_base.py
+++ b/tests/v4/test_properties/test_properties_base.py
@@ -689,8 +689,8 @@ def test_normalize_property_type(property_type, expected):
     (float, float, 0.0),
     (str, str, ''),
     (bool, bool, False),
-    (ObservableList[Axis], ObservableList, None),
-    (ObservableDict[str, bool], ObservableDict, None),
+    (List[Axis], ObservableList, None),
+    (Dict[str, bool], ObservableDict, None),
     (TraceType, TraceType, list(TraceType)[0]),
     (FontStyle, FontStyle, list(FontStyle)[0]),
 ])

--- a/tests/v4/test_properties/test_properties_base.py
+++ b/tests/v4/test_properties/test_properties_base.py
@@ -656,7 +656,7 @@ def test_unpack_union_type(union_type, expected):
     ObservableList[Axis],
 ])
 def test_unpack_union_type_raises_on_non_union(non_union_type):
-    with pytest.raises(ValueError, match="is not a Union type"):
+    with pytest.raises(ValueError, match='is not a Union type'):
         _unpack_union_type(non_union_type)
 
 

--- a/tests/v4/test_widgets/test_structure_widgets.py
+++ b/tests/v4/test_widgets/test_structure_widgets.py
@@ -511,9 +511,9 @@ def test_group_remove_widget():
     lbl1 = Label(name='Label1', text='A', x=0, y=0, width=100, height=20)
     lbl2 = Label(name='Label2', text='B', x=0, y=30, width=100, height=20)
     lbl3 = Label(name='Label3', text='C', x=0, y=60, width=100, height=20)
-    group.add_widget(lbl1)
-    group.add_widget(lbl2)
-    group.add_widget(lbl3)
+    group.widgets.append(lbl1)
+    group.widgets.append(lbl2)
+    group.widgets.append(lbl3)
 
     assert len(group.widgets) == 3
 


### PR DESCRIPTION
This should allow downstream type checkers to allow things like tuples or strings to be used to set color and path properties respectively.

Before this change, something like

```Python
label.background_color = (10, 24, 100)
```

would be legal and work correctly, but would be marked as an issue by type checkers like `ty`, `mypy`, or `pyright`.